### PR TITLE
Ltd is not an acronym and should not be capitalised

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 | hsbc uk bank plc | HSBC UK Bank PLC |
 | cloudera (uk) limited | Cloudera (UK) Limited
 | kfc restaurants limited | KFC Restaurants Limited|
-| a&g holdings ltd | A&G Holdings LTD |
+| a&g holdings ltd | A&G Holdings Ltd |
 | jp morgan | JP Morgan |
 | axa insurance co.| AXA Insurance Co. |
     
-`companycase` uses n-grams to distinguish words that *are or look like dictionary words* (bank, limited, cloudera, deliveroo) from words that do not (HSBC, LTD, HJHJ). Words that do not tend to be acronyms and abbreviations in the context of a company name, and are thus capitalised.
+`companycase` uses n-grams to distinguish words that *are or look like dictionary words* (bank, limited, cloudera, deliveroo) from words that do not (HSBC, JP, HJHJ). Words that do not tend to be acronyms in the context of a company name, and are thus capitalised.
 
 ### Installation
 

--- a/companycase/companycase.py
+++ b/companycase/companycase.py
@@ -12,7 +12,7 @@ class CompanyCase:
 
         # While most sensible parameters will capitalize the acronyms, forcing them here
         # to make sure they don't get title cased for whatever set of parameters.
-        self.force_case = ['of', 'and', 'IT', 'PLC', 'LLC', 'LTD', 'LLP']
+        self.force_case = ['of', 'and', 'IT', 'PLC', 'LLC', 'Ltd', 'LLP']
 
     def find_ngrams(self, input_list, n):
         """ Returns a list of n-grams """


### PR DESCRIPTION
`Ltd.` is an abbreviation, like `Inc.`, and not an acronym like `LLP` or `PLC`.
This patch forces `Ltd` to be title cased.